### PR TITLE
updated link for non-technical blog on main webpage of docs

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -26,7 +26,7 @@ import Image from 'next/image'
 Reclaim Protocol generates cryptographic proofs on HTTPS traffic. The type of cryptographic proof it generates is called a [zero knowledge proof](https://en.wikipedia.org/wiki/Zero-knowledge_proof). It lets the user generate the proof without knowledge of anything other than what the user wants to share with you. The Protocol is built upon open standards such as HTTPS and TLS.
 
 You can learn more here
-- [A non technical overview of how Reclaim Works](https://blog.reclaimprotocol.org/posts/what-is-reclaimprotocol)
+- [A non technical overview of how Reclaim Works](https://blog.reclaimprotocol.org/posts/reclaim-explained)
 - [A technical deepdive via our Whitepaper](https://link.reclaimprotocol.org/whitepaper-draft)
 
 ## Is this safe to use?


### PR DESCRIPTION
### **Summary**
This PR fixes an issue where the link to the non-technical blog on the main webpage of the documentation was broken. The URL has now been updated to point to the correct location.


https://github.com/user-attachments/assets/ba318c43-4574-41cb-bcc6-1f69cfc9512a



### **Changes Made:**
Corrected the URL in the documentation's main webpage to ensure it directs users to the correct non-technical blog.

### **Testing:**
Verified the updated link works as expected.

https://github.com/user-attachments/assets/6a31f301-4371-41d3-acbe-e0f17bd0ba99

