### PR TITLE
Add provider schema to overrides documentation in inapp section

### DIFF
--- a/content/docs/inapp-sdks/ionic-capacitor.mdx
+++ b/content/docs/inapp-sdks/ionic-capacitor.mdx
@@ -132,6 +132,7 @@ Ignore if you already have this declaration in your `Podfile`.
 
 2. Add the following to your `Podfile` to override SDK dependency:
 
+- This step is only required when facing issues with the resolved pod dependency.
 - You can override the version of dependency when you wish to use a specific version of the SDK.
 - You can add a declaration in your `Podfile` to install the SDK from cocoapods, or from a specific git tag, head, commit, or branch.
 
@@ -192,7 +193,10 @@ There are open issues on both capacitor and golang's issue tracker to dicuss thi
 * https://github.com/ionic-team/capacitor/issues/7844
 * https://github.com/golang/go/issues/58225
 
-A workaround is available to fix this issue and requires a custom view controller to be used in ios.
+A simple workaround is available to fix this issue and requires a custom view controller to be used in ios.
+
+<Accordions>
+<Accordion title="Steps for fixing runtime routing issue on iOS">
 
 1. First, create a PatchedViewController.swift file by [opening Xcode](https://capacitorjs.com/docs/ios#opening-the-ios-project), right-clicking on the **App** group (under the App target), selecting **New File from Template** from the context menu, choosing **Cocoa Touch Class** in the window, set the **Subclass of:** to UIViewController in the next screen, and save the file.
 
@@ -234,6 +238,9 @@ class PatchedViewController: CAPBridgeViewController {
     }
 }
 ```
+
+</Accordion>
+</Accordions>
 
 #### Fixing performance issues on IOS physical devices
 

--- a/content/docs/inapp-sdks/react-native.mdx
+++ b/content/docs/inapp-sdks/react-native.mdx
@@ -134,6 +134,7 @@ Ignore if you already have this declaration in your `Podfile`.
 
 2. Add the following to your `Podfile` to override SDK dependency:
 
+- This step is only required when facing issues with the resolved pod dependency.
 - You can override the version of dependency when you wish to use a specific version of the SDK.
 - You can add a declaration in your `Podfile` to install the SDK from cocoapods, or from a specific git tag, head, commit, or branch.
 

--- a/content/docs/inapp-sdks/usage/overrides.mdx
+++ b/content/docs/inapp-sdks/usage/overrides.mdx
@@ -4,6 +4,7 @@ description: Instructions on how to override the default configuration of Reclai
 ---
 
 import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
 # Get Started
 
@@ -52,8 +53,113 @@ provider: {
 }
 ```
 
-- The JSON string or url must point to a valid provider configuration that follows the [provider schema](schemas/provider.schema).
-- Examples of provider configurations can be found in the `https://api.reclaimprotocol.org/api/providers/${provider_id}` http api. For example, [Devtool's Http Api for Github Username Provider](https://api.reclaimprotocol.org/api/providers/6d3f6753-7ee6-49ee-a545-62f1b1822ae5). Please note: These examples are structured differently. The provider configuration is nested under a 'providers' key, rather than being a root object. Therefore, they cannot be used as direct parameters for provider overrides in this SDK.
+- The JSON string or url must point to a valid provider configuration that follows the [provider schema](#provider-schema).
+
+#### Provider Schema
+
+The Schema of Reclaim HTTP Provider used by Reclaim Protocol's InApp SDKs
+
+<Accordions>
+<Accordion title="Schema">
+```prisma
+model HttpProvider {
+  id                      String                              @id
+  httpProviderId          String                              @unique
+  name                    String
+  logoUrl                 String
+  # The url that the user will be redirected to when verification starts.
+  url                     String
+  urlType                 urlType?
+  method                  RequestMethodType                   @default(GET)
+  body                    String?
+  # The url that is likely the login url address of the website used by the provider.
+  loginUrl                String
+  customInjection         String?
+  bodySniff               BodySniff?
+  userAgent               UserAgentSettings?
+  geoLocation             String?
+  matchType               String?                             @default("greedy")
+  injectionType           InjectionType                       @default(MSWJS)
+  disableRequestReplay    Boolean                             @default(false)
+  providerHash            String?
+  additionalClientOptions AdditionalClientOptions?
+  verificationType        VerificationType?                   @default(WITNESS)
+  expectedPageUrl         String?
+  pageTitle               String?
+  requestData             RequestData[]
+}
+
+type AdditionalClientOptions {
+  supportedProtocolVersions TLSVersion[]
+}
+
+enum TLSVersion {
+  TLS1_2
+  TLS1_3
+}
+
+enum InjectionType {
+  MSWJS
+  NONE
+}
+
+type BodySniff {
+  enabled  Boolean?
+  regex    String?
+  template String?
+}
+
+type UserAgentSettings {
+  ios     String?
+  android String?
+}
+
+enum urlType {
+  REGEX
+  CONSTANT
+  TEMPLATE
+}
+
+type RequestData {
+  url                String
+  expectedPageUrl    String?
+  urlType            urlType
+  method             RequestMethodType
+  responseMatches    ResponseMatch[]
+  responseRedactions ResponseRedaction[]
+  bodySniff          BodySniff?
+  # A unique hash of the request data
+  requestHash        String
+}
+
+enum RequestMethodType {
+  GET
+  POST
+}
+
+type ResponseMatch {
+  value       String
+  type        String
+  invert      Boolean @default(false)
+  description String?
+}
+
+type ResponseRedaction {
+  xPath    String?
+  jsonPath String?
+  regex    String?
+  hash     String?
+}
+```
+
+</Accordion>
+</Accordions>
+
+Examples of provider schema can be found as provider configurations in the `https://api.reclaimprotocol.org/api/providers/${provider_id}` http api. For example, [Devtool's Http Api for Github Username Provider](https://api.reclaimprotocol.org/api/providers/6d3f6753-7ee6-49ee-a545-62f1b1822ae5). 
+
+Note:
+- These examples have a different structure where the provider configuration is nested under a 'providers' key, rather than being the root object. Therefore, the `https://api.reclaimprotocol.org/api/providers/${provider_id}` http apis cannot be used as direct parameters for provider overrides by url in this SDK.
+- For use with `jsonString`, provider the value of the 'providers' key in the `jsonString` parameter.
 
 ### Logging Configuration
 


### PR DESCRIPTION
### Description
<!-- Briefly describe the changes in this PR. -->

### Testing (ignore for documentation update)
<!-- Briefly describe how you've tested this implementation -->

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).

### Additional Notes:
<!-- Any other context about the PR. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Clarified instructions for overriding the SDK dependency in both Ionic Capacitor and React Native guides to ensure users perform the step only when necessary.
	- Enhanced guidance on resolving runtime routing issues with a clearer, more approachable workaround description.
	- Introduced structured, accordion-style sections that improve readability and organization of provider configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->