### PR TITLE
Fix typos and formatting in documentation files

### DIFF
--- a/content/docs/attestor-decentralization/attestor-contracts.mdx
+++ b/content/docs/attestor-decentralization/attestor-contracts.mdx
@@ -71,7 +71,7 @@ The [example](https://github.com/reclaimprotocol/attestor-contracts/tree/main/ex
 1.  **Change directory into /examples/attestor and install packages:**
     * `npm install`
 
-2.  **Populate your `.env`, varibales are filled for you, you just need to add you private key (without the `0x` prefix):**
+2.  **Populate your `.env`, variables are filled for you, you just need to add you private key (without the `0x` prefix):**
     * `PRIVATE_KEY=`
 
 3.  **Download zk files:**

--- a/content/docs/sdk/cosmos/neutron-terra.mdx
+++ b/content/docs/sdk/cosmos/neutron-terra.mdx
@@ -130,7 +130,7 @@ you may see a different account address from your wallet address.
 
 That is because Terra's address generation algorithm is different from other cosmos chains and hermes as well.
 
-You should send funds to the account adddress in the json file, as that is the actual address that executes the messages.
+You should send funds to the account address in the json file, as that is the actual address that executes the messages.
 
 ### Configuration file
 

--- a/content/docs/zkfetch/quickstart.mdx
+++ b/content/docs/zkfetch/quickstart.mdx
@@ -114,7 +114,7 @@ All the data in the privateOptions will stay hidden to the verifier.
 const proof = await client.zkFetch('https://your.url.org')
 ```
 
-### Additonal Features 
+### Additional Features 
 
 #### Retries and Retry Interval
 Add retries and set a retry interval for fetch requests:


### PR DESCRIPTION
This PR includes the following documentation improvements:

- Fix typo in "address" word in neutron-terra.mdx
- Fix formatting of "Additional Features" heading in zkfetch/quickstart.mdx
- Minor formatting updates in attestor-contracts.mdx

These changes improve readability and consistency of the documentation.