### PR TITLE
update sophon address

### DIFF
--- a/content/docs/sdk/solidity/supported-networks.mdx
+++ b/content/docs/sdk/solidity/supported-networks.mdx
@@ -123,9 +123,7 @@ description: The Reclaim Protocol Proofs are compatible with blockchain applicat
 
 | Contract          | Address                                    |
 | ----------------- | ------------------------------------------ |
-| Reclaim           | 0x6B2D0193ECF5225b2f1CAB36d833cff719667cf9 |
-| Semaphore         | 0x6cbE32Fb831795c440D038B5C1aF5e9A02C6E582 |
-| SemaphoreVerifier | 0x33131692d3fe8F2dD1a3a768bDA0cb05CaC8DF6a |
+| Reclaim           | 0x52d965a9EcBaCe0a49FE7f9D2197F350C57371ab |
 
 #### Scroll
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the listed contract addresses for the "Sophon" network, now showing only the Reclaim contract with a new address. Removed previously listed Semaphore and SemaphoreVerifier contracts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->