### PR TITLE
deploy to dia testnet

### DIFF
--- a/content/docs/sdk/solidity/supported-networks.mdx
+++ b/content/docs/sdk/solidity/supported-networks.mdx
@@ -351,3 +351,11 @@ description: The Reclaim Protocol Proofs are compatible with blockchain applicat
 | Semaphore         | 0x6cbE32Fb831795c440D038B5C1aF5e9A02C6E582 |
 | SemaphoreVerifier | 0x33131692d3fe8F2dD1a3a768bDA0cb05CaC8DF6a |
 
+#### Dia Lasernet Testnet
+
+| Contract          | Address                                    |
+| ----------------- | ------------------------------------------ |
+| Reclaim           | 0xFAa4bD0487030005341cfa8e26bfBfede2B1D074 |
+| Semaphore         | 0xB68aCB36334311CEc471EE2541173EDc155FdA71 |
+| SemaphoreVerifier | 0x1eE8C8FCB8619A4bbF4360ad73740Eaf61C5e7D7 |
+


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about the new "Dia Lasernet Testnet" to the list of supported networks, including contract addresses for Reclaim, Semaphore, and SemaphoreVerifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->