### PR TITLE
add lukso testnet deployment

### DIFF
--- a/content/docs/sdk/solidity/supported-networks.mdx
+++ b/content/docs/sdk/solidity/supported-networks.mdx
@@ -359,3 +359,11 @@ description: The Reclaim Protocol Proofs are compatible with blockchain applicat
 | Semaphore         | 0xB68aCB36334311CEc471EE2541173EDc155FdA71 |
 | SemaphoreVerifier | 0x1eE8C8FCB8619A4bbF4360ad73740Eaf61C5e7D7 |
 
+#### Lukso Testnet
+
+| Contract          | Address                                    |
+| ----------------- | ------------------------------------------ |
+| Reclaim           | 0xA30ebdF951cF09e411C620745050238b89EB3Ee0 |
+| ProofStorage      | 0x40B2405e8c597F5B9D1BE5adE483c1Dd664db9dE |
+| Semaphore         | 0x8173920daD78Dd39C0B18a537268654B56CeB998 |
+| SemaphoreVerifier | 0x2504D8F71041bd3232df8960701df17ebFd69d57 |


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added information about the Lukso Testnet, including contract addresses for Reclaim, ProofStorage, Semaphore, and SemaphoreVerifier, to the list of supported Solidity SDK networks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->