### PR TITLE
docs: Update SDK import paths in documentation for web and backend (py)

### DIFF
--- a/content/docs/advance-options/web-sdk.mdx
+++ b/content/docs/advance-options/web-sdk.mdx
@@ -255,7 +255,7 @@ The SDK provides a method to verify the verification credentials(proofs) to ensu
 <Tabs items={['JavaScript', 'Flutter', 'Python', 'Rust']}>
   <Tab>
     ```javascript
-    import { verifyProof } from 'reclaim-sdk'
+    import { verifyProof } from '@reclaimprotocol/js-sdk'
 
     // make sure proofObject is of type 'Proof' Object
     const isValid = await verifyProof(proofObject)

--- a/content/docs/web/backend/installation.mdx
+++ b/content/docs/web/backend/installation.mdx
@@ -53,7 +53,7 @@ yarn add @reclaimprotocol/js-sdk
 
     You can verify the installation by running:
     ```bash
-    pip show reclaim-sdk
+    pip show reclaim-python-sdk
     ```
 
     #### Importing the SDK


### PR DESCRIPTION

### Description
This PR updates the documentation to use the correct package names and import statements for the Reclaim Protocol SDKs. The changes ensure consistency with the actual published package names:
- Updated JavaScript SDK import from 'reclaim-sdk' to '@reclaimprotocol/js-sdk'
- Updated Python SDK package name from reclaim-sdk to reclaim-python-sdk in the installation verification command


### Testing (ignore for documentation update)
n/a

### Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update

### Checklist:
- [x] I have read and agree to the [Code of Conduct](https://github.com/reclaimprotocol/.github/blob/main/Code-of-Conduct.md).
- [x] I have signed the [Contributor License Agreement (CLA)](https://github.com/reclaimprotocol/.github/blob/main/CLA.md).
- [x] I have considered the [Security Policy](https://github.com/reclaimprotocol/.github/blob/main/SECURITY.md).
- [x] I have self-reviewed and tested my code.
- [x] I have updated documentation as needed.
- [x] I agree to the [project's custom license](https://github.com/reclaimprotocol/.github/blob/main/LICENSE).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated JavaScript example to use the correct import path for the verification function.
  * Corrected Python SDK installation verification command to reflect the proper package name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->